### PR TITLE
Added fix: FTBFS: Error: Unrecognized opcode: 'lock'

### DIFF
--- a/src/c/src/mt_adaptor.c
+++ b/src/c/src/mt_adaptor.c
@@ -484,11 +484,7 @@ int32_t fetch_and_add(volatile int32_t* operand, int incr)
 {
 #ifndef WIN32
     int32_t result;
-    asm __volatile__(
-         "lock xaddl %0,%1\n"
-         : "=r"(result), "=m"(*(int *)operand)
-         : "0"(incr)
-         : "memory");
+   result = __sync_fetch_and_add(operand, incr);
    return result;
 #else
     volatile int32_t result;


### PR DESCRIPTION
Added changes as per the fix given at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=568618
